### PR TITLE
Add table xref for Ryuho exploit fix in 1.1.1

### DIFF
--- a/bdat.py
+++ b/bdat.py
@@ -8965,6 +8965,7 @@ field_xrefs = {
     'IgnoreCondition': refset_condition,
     'NameCondition': refset_condition,
     'PriceCondition': refset_condition,
+    'field_EF32E8B1': refset_condition,  # Added in 1.1.1, used to prevent Ryuho exploit
 
     'CookRecipe': 'FLD_CookRecipe',
 


### PR DESCRIPTION
They added a new column. Don't have its name, but the one enemy it has a non-zero value for is Ryuho where the value matches the new condition in FLD_ConditionList that checks that you've reached far enough in the story to fight Ryuho.